### PR TITLE
Entity: accepts given strategy for belongsToMany

### DIFF
--- a/LeanMapperQuery/Exception/InvalidStrategyException.php
+++ b/LeanMapperQuery/Exception/InvalidStrategyException.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * This file is part of the LeanMapperQuery extension
+ * for the Lean Mapper library (http://leanmapper.com)
+ * Copyright (c) 2013 Michal Bohuslávek
+ */
+
+namespace LeanMapperQuery\Exception;
+
+/**
+ * @internal
+ */
+class InvalidStrategyException extends Exception
+{
+}

--- a/tests/LeanMapperQuery/Entity.strategy.explicit.phpt
+++ b/tests/LeanMapperQuery/Entity.strategy.explicit.phpt
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Test: LeanMapperQuery\Entity.
+ */
+
+use LeanMapper\Repository;
+use LeanMapperQuery\Entity;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+class BaseEntity extends Entity
+{
+	public function find($field, $query)
+	{
+		$entities = $this->queryProperty($field, $query);
+		return $this->entityFactory->createCollection($entities);
+	}
+}
+
+class BaseRepository extends Repository
+{
+	public function findAll()
+	{
+		return $this->createEntities($this->createFluent()->fetchAll());
+	}
+}
+
+class BookRepository extends BaseRepository
+{
+}
+
+class AuthorRepository extends BaseRepository
+{
+}
+
+/**
+ * @property int    $id
+ * @property string $name
+ */
+class Tag extends BaseEntity
+{
+}
+
+/**
+ * @property int         $id
+ * @property Tag[]       $tags        m:hasMany(#union)
+ * @property string      $name
+ */
+class Book extends BaseEntity
+{
+}
+
+/**
+ * @property int         $id
+ * @property Book[]      $books         m:belongsToMany(#union)
+ */
+class Author extends BaseEntity
+{
+}
+
+////////////////
+// belongsToMany
+
+$authorRepository = new AuthorRepository($connection, $mapper, $entityFactory);
+$authors = $authorRepository->findAll();
+$result = [];
+
+foreach ($authors as $author) {
+	$books = $author->find('books', getQuery()
+		->limit(1)
+	);
+
+	$book = reset($books);
+	$result[$author->id] = $book ? $book->name : NULL;
+}
+
+Assert::same([
+	1 => 'The Pragmatic Programmer',
+	2 => 'The Art of Computer Programming',
+	3 => 'Refactoring: Improving the Design of Existing Code',
+	4 => NULL,
+	5 => 'Introduction to Algorithms',
+], $result);
+
+////////////////
+// hasMany: TODO

--- a/tests/LeanMapperQuery/Entity.strategy.implicit.phpt
+++ b/tests/LeanMapperQuery/Entity.strategy.implicit.phpt
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Test: LeanMapperQuery\Entity.
+ */
+
+use LeanMapper\Repository;
+use LeanMapperQuery\Entity;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+class BaseEntity extends Entity
+{
+	public function find($field, $query)
+	{
+		$entities = $this->queryProperty($field, $query);
+		return $this->entityFactory->createCollection($entities);
+	}
+}
+
+class BaseRepository extends Repository
+{
+	public function findAll()
+	{
+		return $this->createEntities($this->createFluent()->fetchAll());
+	}
+}
+
+class BookRepository extends BaseRepository
+{
+}
+
+class AuthorRepository extends BaseRepository
+{
+}
+
+/**
+ * @property int    $id
+ * @property string $name
+ */
+class Tag extends BaseEntity
+{
+}
+
+/**
+ * @property int         $id
+ * @property Tag[]       $tags        m:hasMany
+ * @property string      $name
+ */
+class Book extends BaseEntity
+{
+}
+
+/**
+ * @property int         $id
+ * @property Book[]      $books         m:belongsToMany
+ */
+class Author extends BaseEntity
+{
+}
+
+////////////////
+// belongsToMany
+
+$authorRepository = new AuthorRepository($connection, $mapper, $entityFactory);
+$authors = $authorRepository->findAll();
+$result = [];
+
+foreach ($authors as $author) {
+	$books = $author->find('books', getQuery()
+		->limit(1)
+	);
+
+	$book = reset($books);
+	$result[$author->id] = $book ? $book->name : NULL;
+}
+
+Assert::same([
+	1 => 'The Pragmatic Programmer',
+	2 => 'The Art of Computer Programming',
+	3 => 'Refactoring: Improving the Design of Existing Code',
+	4 => NULL,
+	5 => 'Introduction to Algorithms',
+], $result);
+
+////////////////
+// hasMany: TODO


### PR DESCRIPTION
Pokud se dotazujeme přes property v entitě pomocí `belongsToMany` a zároveň chceme daný výsledek limitovat (např. pro každého autora získat jen jednu knihu), musíme v anotaci aktivovat UNION strategii -
 tu ale nyní knihovna ignoruje, takže dojde k načtení špatných dat.

Testy budou pravděpodobně padat kvůli [bugu](https://github.com/Tharos/LeanMapper/pull/109) v Lean Mapperu.

Stejná situace nastává i u `hasMany` vazeb, tam je ale situace složitější a nepodařilo se mi ji vyřešit - otevřu pro to ještě jedno PR.