### PR TITLE
Query: Add groupBy()

### DIFF
--- a/LeanMapperQuery/Query.php
+++ b/LeanMapperQuery/Query.php
@@ -30,6 +30,7 @@ use LeanMapperQuery\Exception\NotImplementedException;
  * @method Query desc(bool $desc = TRUE)
  * @method Query limit(int $limit)
  * @method Query offset(int $offset)
+ * @method Query groupBy($field)
  */
 class Query implements IQuery, \Iterator
 {
@@ -575,6 +576,12 @@ class Query implements IQuery, \Iterator
 	private function commandOffset($offset)
 	{
 		$this->fluent->offset($offset);
+	}
+
+	protected function commandGroupBy($field)
+	{
+		$statement = $this->parseStatement($field);
+		$this->getFluent()->groupBy($statement);
 	}
 
 	//////////////////// Iterator //////////////////////

--- a/tests/LeanMapperQuery/Query.groupBy.phpt
+++ b/tests/LeanMapperQuery/Query.groupBy.phpt
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Test: LeanMapperQuery\Query::groupBy().
+ * @author Michal Bohuslávek
+ */
+
+use LeanMapper\Entity;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+/**
+ * @property int           $id
+ * @property Tag[]         $tags      m:hasMany
+ * @property DateTime      $pubdate   m:type(date)
+ * @property string        $name
+ * @property string|NULL   $website
+ * @property bool          $available
+ */
+class Book extends Entity
+{
+}
+
+/**
+ * @property int        $id
+ * @property Book       $book m:hasOne
+ * @property Borrower   $borrower m:hasOne
+ * @property DateTime   $date
+ */
+class Borrowing extends Entity
+{
+}
+
+/**
+ * @property int      $id
+ * @property string   $name
+ */
+class Borrower extends Entity
+{
+}
+
+
+/**
+ * @property int      $id
+ * @property string   $name
+ */
+class Tag extends Entity
+{
+}
+
+// Test replacing placeholders
+$fluent = getFluent('borrowing');
+getQuery()
+	->groupBy('@book')
+	->applyQuery($fluent, $mapper);
+
+$expected = getFluent('borrowing')
+	->groupBy('[borrowing].[book_id]');
+
+Assert::same($expected->_export(), $fluent->_export());


### PR DESCRIPTION
Tak nevím, jestli má tenhle PR smysl, teď jsem si všiml staršího zamítnutého PR #2 :) Důvody zamítnutí beru. Alespoň uvedu, proč si myslím, že by `groupBy` mělo být součástí jádra:

1) nebaví mě to kopírovat do každého projektu :)
2) při použití JOINŮ se můžou ve výsledku vyskytnout duplicitní řádky a někdy je potřeba je pomocí `groupBy` "odfiltrovat"
3) pokud by vznikla nějaká knihovna (např. datasource do datagridu), která by stavěla nad `Query` a potřebovala k něčemu použít `groupBy` (třeba kvůli problému popsanému v bodě 2)), musela by se spoléhat na to, že si uživatel sám `commandGroupBy` dopíše

Ta 2) není sice zase tak častá, protože obvykle načítáme pole entit a `LeanMapper\Repository::createEntities()` záznamy se stejným ID přepíše a vrátí jen unikátní položky. Když ale člověk potřebuje pouze zjistit počet záznamů a zavolá `$query->count()`, dostane špatný výsledek. To je způsobeno tím, že interně se zavolá `count($fluent)`, které Dibi přeloží na `SELECT COUNT(*) ...` a které zahrne i ty nechtěné duplicitní záznamy. Dost často (=skoro na každém projektu) na to narážím třeba v souvislosti se stránkováním filtrovaných záznamů.

Ale třeba to jen celou dobu používám špatně a má to i jiné řešení :)