### PR TITLE
Query: add automatic GROUP BY for JOINs

### DIFF
--- a/LeanMapperQuery/Query.php
+++ b/LeanMapperQuery/Query.php
@@ -150,6 +150,7 @@ class Query implements IQuery, \Iterator
 			list($currentTable, $referencingColumn, $targetTable, $targetTablePrimaryKey, $globalKey, $alias) = $this->possibleJoin;
 			$this->fluent->leftJoin("[$targetTable]" . ($targetTable !== $alias ? " [$alias]" : ''))
 				->on("[$currentTable].[$referencingColumn] = [$alias].[$targetTablePrimaryKey]");
+			$this->tryAddGroupBy($this->fluent, $currentTable);
 			$this->registerTableAlias($globalKey, $alias);
 			$this->possibleJoin = NULL;
 		}
@@ -204,6 +205,7 @@ class Query implements IQuery, \Iterator
 				}
 				$this->fluent->leftJoin($subFluent, "[$alias]")
 					->on("[$currentTable].[$referencingColumn] = [$alias].[$targetTablePrimaryKey]");
+				$this->tryAddGroupBy($this->fluent, $currentTable);
 				$this->registerTableAlias($globalKey, $alias);
 			}
 		}
@@ -279,6 +281,15 @@ class Query implements IQuery, \Iterator
 			} else {
 				return self::$defaultPlaceholder;
 			}
+		}
+	}
+
+	private function tryAddGroupBy(Fluent $fluent, $table)
+	{
+		$groupBy = $fluent->_export('GROUP BY');
+
+		if (empty($groupBy)) {
+			$fluent->groupBy('%n.%n', $table, $this->mapper->getPrimaryKey($table));
 		}
 	}
 

--- a/LeanMapperQuery/Query.php
+++ b/LeanMapperQuery/Query.php
@@ -446,7 +446,8 @@ class Query implements IQuery, \Iterator
 		if (count($fromClause) > 3) { // complicated from clause
 			$subFluent = clone $fluent;
 			// Reset fluent.
-			foreach (array_keys(\DibiFluent::$separators) as $separator) {
+			$separators = (class_exists('Dibi\Fluent')) ? \Dibi\Fluent::$separators : \DibiFluent::$separators;
+			foreach (array_keys($separators) as $separator) {
 				$fluent->removeClause($separator);
 			}
 			// If there are some joins, enwrap the original fluent to enable

--- a/tests/LeanMapperQuery/Query.filters.phpt
+++ b/tests/LeanMapperQuery/Query.filters.phpt
@@ -81,5 +81,6 @@ $expected->select('*')->from(
 			->where(FILTER)
 		, '[author]')
 	->on('[book].[author_id] = [author].[id]')
-	->where('([author].[id] = 2)');
+	->where('([author].[id] = 2)')
+	->groupBy('[book].[id]');
 Assert::same((string) $expected, (string) $fluent);

--- a/tests/LeanMapperQuery/Query.joins-groupBy.phpt
+++ b/tests/LeanMapperQuery/Query.joins-groupBy.phpt
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Test: LeanMapperQuery\Query automatic joins.
+ * @author Michal Bohuslávek
+ */
+
+use LeanMapper\Entity;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+/**
+ * @property int    $id
+ * @property string $name
+ */
+class Tag extends Entity
+{
+}
+
+/**
+ * @property int         $id
+ * @property Author      $author      m:hasOne
+ * @property Author|NULL $reviewer    m:hasOne(reviewer_id)
+ * @property Borrowing[] $borrowings  m:belongsToMany
+ * @property string      $pubdate
+ * @property string      $name
+ * @property string|NULL $description
+ * @property string|NULL $website
+ * @property bool        $available
+ */
+class Book extends Entity
+{
+}
+
+/**
+ * @property int         $id
+ * @property Book        $book      m:hasOne
+ * @property string      $date
+ */
+class Borrowing extends Entity
+{
+}
+
+/**
+ * @property int         $id
+ * @property string      $name
+ * @property Book[]      $books         m:belongsToMany
+ * @property Book[]      $reviewedBooks m:belongsToMany(reviewer_id)
+ * @property string|NULL $web
+ */
+class Author extends Entity
+{
+}
+
+//////// Basic test ////////
+
+$fluent = getFluent('author');
+$query = getQuery();
+$query->orderBy('@books.borrowings.date DESC')
+	->applyQuery($fluent, $mapper);
+
+Assert::same(5, $fluent->count());
+
+$fluent->removeClause('GROUP BY');
+Assert::same(8, $fluent->count());

--- a/tests/LeanMapperQuery/Query.joins.phpt
+++ b/tests/LeanMapperQuery/Query.joins.phpt
@@ -79,7 +79,8 @@ $query->where('@author.name', 'Karel')
 
 $expected = getFluent('book')
 	->leftJoin('author')->on('[book].[author_id] = [author].[id_author]')
-	->where("([author].[name] = 'Karel')");
+	->where("([author].[name] = 'Karel')")
+	->groupBy('[book].[id]');
 Assert::same((string) $expected, (string) $fluent);
 
 // BelongsTo relationship
@@ -90,7 +91,8 @@ getQuery()
 
 $expected = getFluent('author')
 	->leftJoin('book')->on('[author].[id_author] = [book].[author_id]')
-	->where('([book].[available] = 1)');
+	->where('([book].[available] = 1)')
+	->groupBy('[author].[id_author]');
 Assert::same((string) $expected, (string) $fluent);
 
 // HasMany relationship
@@ -102,7 +104,8 @@ getQuery()
 $expected = getFluent('book')
 	->leftJoin('book_tag')->on('[book].[id] = [book_tag].[book_id]')
 	->leftJoin('tag')->on('[book_tag].[tag_id] = [tag].[id]')
-	->where("([tag].[name] <> 'php')");
+	->where("([tag].[name] <> 'php')")
+	->groupBy('[book].[id]');
 Assert::same((string) $expected, (string) $fluent);
 
 //////// Multiple join of the same table ////////
@@ -115,7 +118,8 @@ $expected = getFluent('book')
 	->leftJoin('author')->on('[book].[author_id] = [author].[id_author]')
 	->leftJoin('[author] [author_reviewer_id]')->on('[book].[reviewer_id] = [author_reviewer_id].[id_author]')
 	->where("([author].[name] = 'Karel')")
-	->where("([author_reviewer_id].[web] = 'http://leanmapper.com')");
+	->where("([author_reviewer_id].[web] = 'http://leanmapper.com')")
+	->groupBy('[book].[id]');
 Assert::same((string) $expected, (string) $fluent);
 
 //////// Optional specifying of primary key ////////
@@ -138,7 +142,8 @@ getQuery()
 
 $expected = getFluent('book')
 	->leftJoin('book_tag')->on('[book].[id] = [book_tag].[book_id]')
-	->where('([book_tag].[tag_id] = 2)');
+	->where('([book_tag].[tag_id] = 2)')
+	->groupBy('[book].[id]');
 Assert::same((string) $expected, (string) $fluent);
 
 // BelongsTo
@@ -149,7 +154,8 @@ getQuery()
 
 $expected = getFluent('author')
 	->leftJoin('book')->on('[author].[id_author] = [book].[author_id]')
-	->where('([book].[id] = 2)');
+	->where('([book].[id] = 2)')
+	->groupBy('[author].[id_author]');
 Assert::same((string) $expected, (string) $fluent);
 
 //////// Multiple joins ////////
@@ -164,7 +170,8 @@ $expected = getFluent('book')
 	->leftJoin('[book] [book_id_author]')->on('[author].[id_author] = [book_id_author].[author_id]')
 	->leftJoin('book_tag')->on('[book_id_author].[id] = [book_tag].[book_id]')
 	->leftJoin('tag')->on('[book_tag].[tag_id] = [tag].[id]')
-	->where("([tag].[name] = 'foo')");
+	->where("([tag].[name] = 'foo')")
+	->groupBy('[book].[id]');
 Assert::same((string) $expected, (string) $fluent);
 
 Assert::throws(function () use ($mapper){
@@ -182,5 +189,6 @@ getQuery()
 $expected = getFluent('book')
 	->leftJoin('book_tag')->on('[book].[id] = [book_tag].[book_id]')
 	->where('([book].[author_id] = 2)')
-	->where('([book_tag].[tag_id] = 2)');
+	->where('([book_tag].[tag_id] = 2)')
+	->groupBy('[book].[id]');
 Assert::same((string) $expected, (string) $fluent);


### PR DESCRIPTION
Navazuje na diskusi v PR #6.

Následující řešení přidává automatický GROUP BY při JOINování dalších tabulek. Zabraňuje tak započítání duplicitních řádků při `count()` a v dalších obdobných případech.