### PR TITLE
Query: fix identifier escaping

### DIFF
--- a/LeanMapperQuery/Query.php
+++ b/LeanMapperQuery/Query.php
@@ -452,7 +452,8 @@ class Query implements IQuery, \Iterator
 			}
 			// If there are some joins, enwrap the original fluent to enable
 			// accessing columns from joined tables.
-			$fluent->select('*')->from($subFluent, $this->sourceTableName);
+			$fluent->select('*')->from($subFluent)
+				->as($this->sourceTableName);
 		}
 
 		$this->fluent = $fluent;

--- a/tests/LeanMapperQuery/Query.filters.phpt
+++ b/tests/LeanMapperQuery/Query.filters.phpt
@@ -75,7 +75,7 @@ $expected->select('*')->from(
 		getFluent('book')
 			->join('test')->on('[book].[id] = [test].[book_id]')
 			->where(FILTER)
-		, 'book')
+		)->as('book')
 	->leftJoin(
 		getFluent('author')
 			->where(FILTER)


### PR DESCRIPTION
Všiml jsem si, že při použití `$fluent->select('*')->from($subFluent, $this->sourceTableName);` není `sourceTableName` vůbec escapován - teoreticky by to mohlo způsobit problém.

Např. v testech to tedy generovalo dotaz:

```sql
SELECT * FROM
(SELECT [book].* FROM [book] JOIN [test] ON [book].[id] = [test].[book_id] WHERE 1 = 1) book
LEFT JOIN (SELECT [author].* FROM [author] WHERE 1 = 1) [author] ON [book].[author_id] = [author].[id]
WHERE ([author].[id] = 2)
GROUP BY [book].[id]
```

místo

```sql
SELECT * FROM
(SELECT [book].* FROM [book] JOIN [test] ON [book].[id] = [test].[book_id] WHERE 1 = 1) AS [book]
LEFT JOIN (SELECT [author].* FROM [author] WHERE 1 = 1) [author] ON [book].[author_id] = [author].[id]
WHERE ([author].[id] = 2)
GROUP BY [book].[id]
```