### PR TITLE
WIP! Drop support for Lean Mapper 2 and PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ php:
   - 7.1
   - 7.2
 
-matrix:
-  include:
-    - php: 5.3
-      dist: precise
-
 script:
   - vendor/bin/tester tests -s -p php
   - php temp/code-checker/src/code-checker.php

--- a/LeanMapperQuery/Query.php
+++ b/LeanMapperQuery/Query.php
@@ -446,8 +446,7 @@ class Query implements IQuery, \Iterator
 		if (count($fromClause) > 3) { // complicated from clause
 			$subFluent = clone $fluent;
 			// Reset fluent.
-			$separators = (class_exists('Dibi\Fluent')) ? \Dibi\Fluent::$separators : \DibiFluent::$separators;
-			foreach (array_keys($separators) as $separator) {
+			foreach (array_keys(\Dibi\Fluent::$separators) as $separator) {
 				$fluent->removeClause($separator);
 			}
 			// If there are some joins, enwrap the original fluent to enable

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
 		}
 	},
 	"require": {
-		"php": ">=5.3.0",
-		"tharos/leanmapper": ">=2.3"
+		"php": ">=5.4.0",
+		"tharos/leanmapper": ">=3.0"
 	},
 	"require-dev": {
 		"nette/tester": "~1.2"


### PR DESCRIPTION
Odstranění podpory pro LM2 a PHP 5.3. Prakticky to znamená v podstatě jen úpravu composer.json a travis.yml - zbytek kódu je skoro beze změn.

Máš nějaké další nápady, co by se v rámci této úpravy dalo změnit?