### PR TITLE
Single table inheritance - limitace pomocí property potomka

### DIFF
--- a/LeanMapperQuery/ICaster.php
+++ b/LeanMapperQuery/ICaster.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the LeanMapperQuery extension
+ * for the Lean Mapper library (http://leanmapper.com)
+ * Copyright (c) 2013 Michal Bohuslávek
+ */
+
+namespace LeanMapperQuery;
+
+use LeanMapper\Fluent;
+
+interface ICaster
+{
+
+	/**
+	 * @param  Fluent $fluent
+	 * @param  string $entityClass
+	 * @return void
+	 */
+	public function castTo(Fluent $fluent, $entityClass);
+}

--- a/tests/LeanMapperQuery/Query.cast.phpt
+++ b/tests/LeanMapperQuery/Query.cast.phpt
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Test: LeanMapperQuery\Entity.
+ */
+
+use LeanMapper\Repository;
+use LeanMapperQuery\Entity;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+$query = getQuery()->cast('Tag');
+
+Assert::exception(function () use ($query) {
+	$query->cast('Book');
+
+}, 'LeanMapperQuery\Exception\InvalidStateException', 'Entity class is already casted to Tag class.');


### PR DESCRIPTION
Narazil jsem na takový problém se STI - potřebuji v aplikaci výsledky omezit pomocí property, která je definována v poděděné třídě. Typický příklad:

* Client
   * id
   * name
* ClientCompany extends Client
   * ic
   * dic
* ClientIndividual extends Client
   * birthDate

A potřebuji najít v DB záznamy podle sloupce `ic`. Query object mi samozřejmě vyhodí chybu `Entity 'Client' doesn't have property 'ic'.`.

Posílám upravený test, aby bylo vidět o co přesně mi jde.

Napadá tě nějaké řešení, jak by se to dalo na straně query objectu vyřešit? V aplikaci si to prozatím nějak obejdu, ale bylo by hezké, kdyby to query object uměl.

Koukal jsem třeba na Nextras ORM a tam to řeší tak, že v dotazu uvedou třídu a property (viz https://nextras.org/orm/docs/3.0/entity-sti#toc-usage).

Možná by tedy řešením bylo rozšířit syntaxi třeba o

```php
$query->where('@ClientCompany::ic', 'value')
```
nebo

```php
$query->where('@::ic', ClientCompany::class, 'value')
```
(aby se název třídy nemusel zapisovat jako řetězec, ale mohlo se využít [`ClassName::class`](http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.class), alternativně by šlo použít i obyčejné spojení řetězců)
```php
$query->where('@' . ClientCompany::class . '::ic', 'value')
```

Co myslíš?