### PR TITLE
EntityMixin

### DIFF
--- a/tests/LeanMapperQuery/Entity.custom.phpt
+++ b/tests/LeanMapperQuery/Entity.custom.phpt
@@ -1,0 +1,107 @@
+<?php
+
+use LeanMapper\Repository;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+class BaseEntity extends LeanMapper\Entity
+{
+	public function find($field, $query)
+	{
+		$entities = LeanMapperQuery\Entity::queryEntityProperty($this, $field, $query);
+		return $this->entityFactory->createCollection($entities);
+	}
+}
+
+class BaseRepository extends Repository
+{
+	public function findAll()
+	{
+		return $this->createEntities($this->createFluent()->fetchAll());
+	}
+}
+
+class BookRepository extends BaseRepository
+{
+}
+
+class AuthorRepository extends BaseRepository
+{
+}
+
+/**
+ * @property int    $id
+ * @property string $name
+ */
+class Tag extends BaseEntity
+{
+}
+
+/**
+ * @property int         $id
+ * @property Author      $author      m:hasOne
+ * @property Author|NULL $reviewer    m:hasOne(reviewer_id)
+ * @property Tag[]       $tags        m:hasMany
+ * @property string      $pubdate
+ * @property string      $name
+ * @property string|NULL $description
+ * @property string|NULL $website
+ * @property bool        $available
+ */
+class Book extends BaseEntity
+{
+}
+
+/**
+ * @property int         $id
+ * @property string      $name
+ * @property Book[]      $books         m:belongsToMany
+ * @property Book[]      $reviewedBooks m:belongsToMany(reviewer_id)
+ * @property string|NULL $web
+ */
+class Author extends BaseEntity
+{
+}
+
+////////////////
+
+$bookRepository = new BookRepository($connection, $mapper, $entityFactory);
+$books = $bookRepository->findAll();
+$book = $books[1];
+
+$bookTags = $book->find('tags', getQuery()
+	->where('@name', 'ebook')
+);
+
+Assert::same(1, count($bookTags));
+
+$authorRepository = new AuthorRepository($connection, $mapper, $entityFactory);
+$authors = $authorRepository->findAll();
+$author = $authors[1];
+
+$authorBooks = $author->find('books', getQuery()
+	->where('@available', FALSE)
+);
+
+Assert::same(0, count($authorBooks));
+
+// exceptions
+$book = $books[2];
+
+Assert::exception(function () use ($book) {
+	$book->find('author', getQuery());
+}, 'LeanMapperQuery\\Exception\\InvalidRelationshipException');
+
+Assert::exception(function () use ($book) {
+	$book->find('name', getQuery());
+}, 'LeanMapperQuery\\Exception\\InvalidArgumentException');
+
+Assert::exception(function () use ($book) {
+	$book->find('xyz', getQuery());
+}, 'LeanMapperQuery\\Exception\\MemberAccessException');
+
+Assert::exception(function () {
+	$book = new Book;
+	$book->find('xyz', getQuery());
+}, 'LeanMapperQuery\\Exception\\InvalidStateException');


### PR DESCRIPTION
Řeším ještě jeden problém, který mi brání v tom úplně opustit můj fork.

# Problém

Pokud chci dotazovat položky entity, musím aktuálně podědit třídu `LeanMapperQuery\Entity`. To třeba v mém případě není úplně možné, protože mám vlastní sadu BaseEntit a LMQuery používám jen jako volitelné rozšíření. Ta dědičnost entit vypadá nějak takhle:

* `LeanMapper\Entity`
* `StrictEntity` (moje knihovna, která přidává do entit trochu striktního chování - nechci a ani nedává smysl, aby závisela na LMQuery, mělo by jí být možné použít samostatně)
* `BaseEntity` - základní entita projektu - na ní většinou pomocí trait přidávám požadované featury (LMQuery, aj.)
* konkrétní entity

Samozřejmě na některých projektech je ta struktura košatější, BaseEntit je třeba i víc apod.

# Řešení

Ve svém forku problém řeším tak, že jsem si vykopíroval z `LMQuery\Entity` metodu `queryProperty` a umístil jí do traity `TEntity`. Je to docela obstojné řešení, které se mi ale postupem času přestalo líbit - dost se to spoléhá na vnitřní implementaci `LeanMapper\Entity`, zakrývá to skutečné závislosti apod. Snažil jsem se najít jiné řešení a jediné k čemu jsem došel je přidat statickou třídu `EntityMixin` a metodu `queryProperty` přesunout do ní.

Pokud uživatel potřebuje ve své entitě využít LMQuery a zároveň nemůže dědit přímo `LMQuery\Entity`, jen ve svém kódu zavolá statickou metodu `EntityMixin::queryProperty` a předá jí potřebné závilosti. 

A právě tohle řešení posílám v PR.

Popravdě se mi to taky moc nelíbí (3x jsem to zahodil a pak se k tomu zase vrátil :) ), ale nic lepšího jsem nevymyslel. Třeba přijdeme na něco lepšího.

---

Byl bych hrozně rád, kdyby se tohle dostalo do LMQuery 1.1 - mohl bych konečně ze svých knihoven a projektů vyhodit závilost na forku a použít jen čisté LMQuery.