### PR TITLE
Entity is abstract

### DIFF
--- a/LeanMapperQuery/Entity.php
+++ b/LeanMapperQuery/Entity.php
@@ -25,7 +25,7 @@ use LeanMapperQuery\IQuery;
 /**
  * @author Michal Bohuslávek
  */
-class Entity extends LeanMapper\Entity
+abstract class Entity extends LeanMapper\Entity
 {
 	/** @var array */
 	protected static $magicMethodsPrefixes = [];


### PR DESCRIPTION
Třída `LeanMapperQuery\Entity` by měla být abstraktní, nedává smysl, aby šla sama o sobě instancovat.